### PR TITLE
Fix kernel booting for command tester

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## 1.1.2 [2021-08-05]
+* Fix and simplify kernel booting for command tester (#11)
+
 ## 1.1.1 [2021-06-16]
 * Fix support for Symfony 5.3 (#10)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## 1.1.2 [2021-08-05]
-* Fix and simplify kernel booting for command testergetDependencyInjectionContainer (#11)
+## 1.1.2 [2021-08-09]
+* Fix and simplify kernel booting for command tester (#11)
 
 ## 1.1.1 [2021-06-16]
 * Fix support for Symfony 5.3 (#10)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## 1.1.2 [2021-08-05]
-* Fix and simplify kernel booting for command tester (#11)
+* Fix and simplify kernel booting for command testergetDependencyInjectionContainer (#11)
 
 ## 1.1.1 [2021-06-16]
 * Fix support for Symfony 5.3 (#10)

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,11 +1,6 @@
 parameters:
 	ignoreErrors:
 		-
-			message: "#^Array \\(array\\<Symfony\\\\Component\\\\DependencyInjection\\\\ContainerInterface\\>\\) does not accept object\\|null\\.$#"
-			count: 1
-			path: src/WebTestCase.php
-
-		-
 			message: "#^Parameter \\#1 \\$callable of static method Doctrine\\\\Common\\\\Annotations\\\\AnnotationRegistry\\:\\:registerLoader\\(\\) expects callable\\(\\)\\: mixed, array\\(mixed, 'loadClass'\\) given\\.$#"
 			count: 1
 			path: tests/App/bootstrap.php

--- a/src/WebTestCase.php
+++ b/src/WebTestCase.php
@@ -100,11 +100,13 @@ abstract class WebTestCase extends BaseWebTestCase
             $kernel->boot();
 
             $container = $kernel->getContainer();
+
             if ($container->has('test.service_container')) {
-                $this->containers[$cacheKey] = $container->get('test.service_container');
-            } else {
-                $this->containers[$cacheKey] = $container;
+                $container = $container->get('test.service_container');
+                $this->assertInstanceOf(ContainerInterface::class, $container);
             }
+
+            $this->containers[$cacheKey] = $container;
         }
 
         return $this->containers[$cacheKey];

--- a/src/WebTestCase.php
+++ b/src/WebTestCase.php
@@ -38,7 +38,7 @@ abstract class WebTestCase extends BaseWebTestCase
             /** @var KernelInterface $kernel */
             $kernel = $this->getContainer()->get('kernel');
         } else {
-            $kernel = self::bootKernel();
+            $kernel = self::bootKernel(['environment' => $this->environment]);
         }
 
         $application = new Application($kernel);

--- a/src/WebTestCase.php
+++ b/src/WebTestCase.php
@@ -34,16 +34,11 @@ abstract class WebTestCase extends BaseWebTestCase
      */
     protected function prepareCommandTester(string $name, bool $reuseKernel = false): CommandTester
     {
-        if (! $reuseKernel) {
-            if (null !== static::$kernel) {
-                static::$kernel->shutdown();
-            }
-
-            $kernel = static::$kernel = static::createKernel(['environment' => $this->environment]);
-            $kernel->boot();
-        } else {
+        if ($reuseKernel) {
             /** @var KernelInterface $kernel */
             $kernel = $this->getContainer()->get('kernel');
+        } else {
+            $kernel = self::bootKernel();
         }
 
         $application = new Application($kernel);


### PR DESCRIPTION
Under Symfony 5.3 the command tester fails with this error:
```
Cannot retrieve the container from a non-booted kernel.
```

The kernel was booted but mishandled by custom boot code done while preparing the command tester. We can leverage the dedicated protected method given by the base test case to solve this issue entirely.