### PR TITLE
Fix symfony 8.1 compat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## 1.5.0 [2026-06-TBD]
 * Drop support for PHP below 8.1
 * Drop support for Symfony below 5.4
+* Deprecate `\Facile\SymfonyFunctionalTestCase\WebTestCase::getDependencyInjectionContainer()` in favor of native Symfony `getContainer()`
 
 ## 1.4.0 [2024-11-05]
 * Add support for Symfony 8 (#25)

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,2 +1,13 @@
 parameters:
 	ignoreErrors:
+		-
+			message: '#^Call to an undefined method Facile\\SymfonyFunctionalTestCase\\Tests\\Command\\CommandTest\:\:runCommand\(\)\.$#'
+			identifier: method.notFound
+			count: 3
+			path: tests/Command/CommandTest.php
+
+		-
+			message: '#^Call to an undefined static method Facile\\SymfonyFunctionalTestCase\\Tests\\Command\\CommandTest\:\:runCommand\(\)\.$#'
+			identifier: staticMethod.notFound
+			count: 1
+			path: tests/Command/CommandTest.php

--- a/src/WebTestCase.php
+++ b/src/WebTestCase.php
@@ -8,6 +8,7 @@ use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase as BaseWebTestCase;
 use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\Console\Tester\ExecutionResult;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\KernelInterface;
@@ -48,7 +49,7 @@ abstract class WebTestCase extends BaseWebTestCase
      *
      * @param array<string, mixed> $params
      */
-    protected function runCommand(string $name, array $params = [], bool $reuseKernel = false): CommandTester
+    protected function runCommandTester(string $name, array $params = [], bool $reuseKernel = false): CommandTester
     {
         $commandTester = $this->prepareCommandTester($name, $reuseKernel);
         $commandTester->execute(
@@ -59,6 +60,18 @@ abstract class WebTestCase extends BaseWebTestCase
         );
 
         return $commandTester;
+    }
+
+    /**
+     * @param mixed|null $arguments
+     */
+    public function __call(string $name, $arguments): object
+    {
+        if ('runCommand' === $name) {
+            return $this->runCommandTester(...$arguments);
+        }
+
+        throw new \Exception("Method {$name} is not supported.");
     }
 
     /**

--- a/src/WebTestCase.php
+++ b/src/WebTestCase.php
@@ -77,6 +77,7 @@ abstract class WebTestCase extends BaseWebTestCase
      * Get an instance of the dependency injection container.
      * (this creates a kernel *without* parameters).
      */
+    #[\Deprecated('Prefer using native Symfony getContainer()', '1.5.0')]
     protected function getDependencyInjectionContainer(): ContainerInterface
     {
         $cacheKey = $this->environment;

--- a/src/WebTestCase.php
+++ b/src/WebTestCase.php
@@ -8,7 +8,6 @@ use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase as BaseWebTestCase;
 use Symfony\Component\Console\Tester\CommandTester;
-use Symfony\Component\Console\Tester\ExecutionResult;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\KernelInterface;
@@ -63,9 +62,9 @@ abstract class WebTestCase extends BaseWebTestCase
     }
 
     /**
-     * @param mixed|null $arguments
+     * @param mixed[] $arguments
      */
-    public function __call(string $name, $arguments): object
+    public function __call(string $name, array $arguments): object
     {
         if ('runCommand' === $name) {
             return $this->runCommandTester(...$arguments);

--- a/tests/Command/CommandTest.php
+++ b/tests/Command/CommandTest.php
@@ -9,7 +9,7 @@ use Facile\SymfonyFunctionalTestCase\WebTestCase;
 class CommandTest extends WebTestCase
 {
     /**
-     * This method tests both the default setting of `runCommand()` and the kernel reusing, as, to reuse kernel,
+     * This method tests both the default setting of `runCommandTester()` and the kernel reusing, as, to reuse kernel,
      * it is needed a kernel is yet instantiated. So we test these two conditions here, to not repeat the code.
      */
     public function testRunCommandWithoutOptionsAndReuseKernel(): void
@@ -19,6 +19,31 @@ class CommandTest extends WebTestCase
         $this->assertStringContainsString('Environment: test', $commandTester->getDisplay());
 
         $commandTester = $this->runCommand('facileitsymfonyfunctionaltestcase:test', [], true);
+
+        $this->assertSame(0, $commandTester->getStatusCode());
+        $this->assertStringContainsString('Environment: test', $commandTester->getDisplay());
+    }
+
+    public function testRunCommandTesterSpecificMethod(): void
+    {
+        // Run command without options
+        $commandTester = $this->runCommandTester('facileitsymfonyfunctionaltestcase:test');
+
+        // Test default values
+        $this->assertStringContainsString('Environment: test', $commandTester->getDisplay());
+
+        // Run command and reuse kernel
+        $commandTester = $this->runCommandTester('facileitsymfonyfunctionaltestcase:test', [], true);
+
+        $this->assertInstanceOf(CommandTester::class, $commandTester);
+        $this->assertSame(0, $commandTester->getStatusCode());
+
+        $this->assertStringContainsString('Environment: test', $commandTester->getDisplay());
+    }
+
+    public function testRunCommandParentStaticMethod(): void
+    {
+        $commandTester = self::runCommand('facileitsymfonyfunctionaltestcase:test');
 
         $this->assertSame(0, $commandTester->getStatusCode());
         $this->assertStringContainsString('Environment: test', $commandTester->getDisplay());

--- a/tests/Command/CommandTest.php
+++ b/tests/Command/CommandTest.php
@@ -20,14 +20,12 @@ class CommandTest extends WebTestCase
 
         $commandTester = $this->runCommand('facileitsymfonyfunctionaltestcase:test');
 
-        /** @phpstan-ignore-next-line method.impossibleType */
         $this->assertInstanceOf(CommandTester::class, $commandTester);
         $this->assertStringContainsString('Environment: test', $commandTester->getDisplay());
 
         /** @phpstan-ignore-next-line argument.type */
         $commandTester = $this->runCommand('facileitsymfonyfunctionaltestcase:test', [], true);
 
-        /** @phpstan-ignore-next-line method.impossibleType */
         $this->assertInstanceOf(CommandTester::class, $commandTester);
         $this->assertSame(0, $commandTester->getStatusCode());
         $this->assertStringContainsString('Environment: test', $commandTester->getDisplay());
@@ -71,7 +69,6 @@ class CommandTest extends WebTestCase
 
         $commandTester = $this->runCommand('facileitsymfonyfunctionaltestcase:test');
 
-        /** @phpstan-ignore-next-line method.impossibleType */
         $this->assertInstanceOf(CommandTester::class, $commandTester);
         $this->assertSame(0, $commandTester->getStatusCode());
 
@@ -90,7 +87,6 @@ class CommandTest extends WebTestCase
 
         $commandTester = $this->runCommand('facileitsymfonyfunctionaltestcase:test-status-code');
 
-        /** @phpstan-ignore-next-line method.impossibleType */
         $this->assertInstanceOf(CommandTester::class, $commandTester);
         $this->assertSame(10, $commandTester->getStatusCode());
     }

--- a/tests/Command/CommandTest.php
+++ b/tests/Command/CommandTest.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Facile\SymfonyFunctionalTestCase\Tests\Command;
 
 use Facile\SymfonyFunctionalTestCase\WebTestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\HttpKernel\Kernel;
 
 class CommandTest extends WebTestCase
 {
@@ -14,27 +16,39 @@ class CommandTest extends WebTestCase
      */
     public function testRunCommandWithoutOptionsAndReuseKernel(): void
     {
+        $this->skipIfSymfonyAfter81();
+
         $commandTester = $this->runCommand('facileitsymfonyfunctionaltestcase:test');
 
+        /** @phpstan-ignore-next-line method.impossibleType */
+        $this->assertInstanceOf(CommandTester::class, $commandTester);
         $this->assertStringContainsString('Environment: test', $commandTester->getDisplay());
 
+        /** @phpstan-ignore-next-line argument.type */
         $commandTester = $this->runCommand('facileitsymfonyfunctionaltestcase:test', [], true);
 
+        /** @phpstan-ignore-next-line method.impossibleType */
+        $this->assertInstanceOf(CommandTester::class, $commandTester);
         $this->assertSame(0, $commandTester->getStatusCode());
+        $this->assertStringContainsString('Environment: test', $commandTester->getDisplay());
+    }
+
+    public function testRunCommandTesterGenericMethod(): void
+    {
+        $commandTester = $this->runCommandTester('facileitsymfonyfunctionaltestcase:test');
+
         $this->assertStringContainsString('Environment: test', $commandTester->getDisplay());
     }
 
     public function testRunCommandTesterSpecificMethod(): void
     {
-        // Run command without options
         $commandTester = $this->runCommandTester('facileitsymfonyfunctionaltestcase:test');
 
-        // Test default values
         $this->assertStringContainsString('Environment: test', $commandTester->getDisplay());
 
-        // Run command and reuse kernel
         $commandTester = $this->runCommandTester('facileitsymfonyfunctionaltestcase:test', [], true);
 
+        /** @phpstan-ignore-next-line method.impossibleType */
         $this->assertInstanceOf(CommandTester::class, $commandTester);
         $this->assertSame(0, $commandTester->getStatusCode());
 
@@ -43,21 +57,28 @@ class CommandTest extends WebTestCase
 
     public function testRunCommandParentStaticMethod(): void
     {
+        $this->skipIfSymfonyBefore81();
+
         $commandTester = self::runCommand('facileitsymfonyfunctionaltestcase:test');
 
-        $this->assertSame(0, $commandTester->getStatusCode());
+        $this->assertSame(0, $commandTester->statusCode);
         $this->assertStringContainsString('Environment: test', $commandTester->getDisplay());
     }
 
     public function testRunCommandWithoutOptionsAndNotReuseKernel(): void
     {
+        $this->skipIfSymfonyAfter81();
+
         $commandTester = $this->runCommand('facileitsymfonyfunctionaltestcase:test');
 
+        /** @phpstan-ignore-next-line method.impossibleType */
+        $this->assertInstanceOf(CommandTester::class, $commandTester);
         $this->assertSame(0, $commandTester->getStatusCode());
 
         $this->assertStringContainsString('Environment: test', $commandTester->getDisplay());
 
         $this->environment = 'prod';
+        /** @phpstan-ignore-next-line argument.type */
         $commandTester = $this->runCommand('facileitsymfonyfunctionaltestcase:test', [], false);
 
         $this->assertStringContainsString('Environment: prod', $commandTester->getDisplay());
@@ -65,8 +86,12 @@ class CommandTest extends WebTestCase
 
     public function testRunCommandStatusCode(): void
     {
+        $this->skipIfSymfonyAfter81();
+
         $commandTester = $this->runCommand('facileitsymfonyfunctionaltestcase:test-status-code');
 
+        /** @phpstan-ignore-next-line method.impossibleType */
+        $this->assertInstanceOf(CommandTester::class, $commandTester);
         $this->assertSame(10, $commandTester->getStatusCode());
     }
 
@@ -77,5 +102,19 @@ class CommandTest extends WebTestCase
         $commandTester->execute([]);
 
         $this->assertSame(10, $commandTester->getStatusCode());
+    }
+
+    private function skipIfSymfonyAfter81(): void
+    {
+        if (Kernel::VERSION_ID >= 8_01_00) {
+            $this->markTestSkipped('Test not executable under Symfony 8.1+');
+        }
+    }
+
+    private function skipIfSymfonyBefore81(): void
+    {
+        if (Kernel::VERSION_ID < 8_01_00) {
+            $this->markTestSkipped('Test not executable under Symfony below 8.1');
+        }
     }
 }

--- a/tests/WebTestCaseTest.php
+++ b/tests/WebTestCaseTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Facile\SymfonyFunctionalTestCase\Tests;
 
 use PHPUnit\Framework\Attributes\Depends;
+use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Facile\SymfonyFunctionalTestCase\Tests\App\AppKernel;
 use Facile\SymfonyFunctionalTestCase\WebTestCase;
@@ -25,6 +26,14 @@ class WebTestCaseTest extends WebTestCase
     public function testGetContainer(): void
     {
         $container = $this->getContainer();
+        $this->assertTrue($container->hasParameter('kernel.environment'));
+    }
+
+    #[IgnoreDeprecations]
+    public function testGetDependencyInjectionContainer(): void
+    {
+        $container = $this->getDependencyInjectionContainer();
+
         $this->assertTrue($container->hasParameter('kernel.environment'));
     }
 

--- a/tests/WebTestCaseTest.php
+++ b/tests/WebTestCaseTest.php
@@ -30,10 +30,6 @@ class WebTestCaseTest extends WebTestCase
 
     public function testCallNotGettingMoreCalls(): void
     {
-        if (! method_exists(WebTestCase::class, '__call')) {
-            $this->markTestSkipped('Magic method __call is temporarely removed for PR #30');
-        }
-
         $this->expectExceptionMessage('Method fakeMethod is not supported');
 
         /** @phpstan-ignore-next-line */


### PR DESCRIPTION
Symfony 8.1 introduces a new `\Symfony\Bundle\FrameworkBundle\Test\ConsoleCommandAssertionsTrait::runCommand` static method, which is used in in `\Symfony\Bundle\FrameworkBundle\Test\KernelTestCase`, which in turn is an ancestor of our `\Facile\SymfonyFunctionalTestCase\WebTestCase`.

Since the new method is static and ours isn't, this creates a fatal error when autoloading our class, making the whole PHPUnit execution die. To avoid this, especially in CI pipelines with multiple Symfony versions, we will rename our method and use `__call` to maintain backward compatibility. 

Users that have to upgrade to Symfony 8.1 will have the option to either migrate to the framework's new method or to switch to the new method name. This could also mean that this package is edging toward the end of its usefulness.